### PR TITLE
Bug/max py version

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -20,7 +20,7 @@ sys.path.insert(0, os.path.abspath('../'))
 project = 'TELL'
 copyright = '2022, Batelle Memorial Institute'
 author = 'Casey Burleyson, Casey McGrath'
-version = 'v1.2.0'
+version = '1.2.1'
 
 
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     description='A model to predict total electricity loads',
     long_description=readme(),
     long_description_content_type="text/markdown",
-    python_requires='>=3.9',
+    python_requires='>=3.9, <3.11',
     include_package_data=True,
     install_requires=[
         'setuptools>=49.2.1',

--- a/tell/__init__.py
+++ b/tell/__init__.py
@@ -25,4 +25,4 @@ from .execute_forward import *
 from .visualization import *
 
 # Set the current version of TELL:
-__version__ = '1.2.0'
+__version__ = '1.2.1'

--- a/tell/execute_forward.py
+++ b/tell/execute_forward.py
@@ -164,7 +164,7 @@ def process_population_scenario(scenario_to_process: str, population_data_input_
         population_dft.set_index('yr', inplace=True)
 
         # Interpolate the populations to an annual time-step and transpose the results:
-        population_interp_df = population_dft.resample('1Y').mean().interpolate('linear').T
+        population_interp_df = population_dft.resample('1YE').mean().interpolate('linear').T
 
         # Convert the dataframe from a wide format to a long format and name the population variable:
         population_interp_df = population_interp_df.stack().reset_index()

--- a/tell/install_forcing_data.py
+++ b/tell/install_forcing_data.py
@@ -19,16 +19,19 @@ class InstallForcingSample:
 
     # URL for DOI minted example data hosted on Zenodo
 
-    DATA_VERSION_URLS = {'0.0.1': 'https://zenodo.org/record/6354665/files/sample_forcing_data.zip?download=1',
-                         '0.1.0': 'https://zenodo.org/record/6354665/files/sample_forcing_data.zip?download=1',
-                         '0.1.1': 'https://zenodo.org/record/6354665/files/sample_forcing_data.zip?download=1',
-                         '0.1.2': 'https://zenodo.org/record/6354665/files/sample_forcing_data.zip?download=1',
-                         '0.1.3': 'https://zenodo.org/record/6354665/files/sample_forcing_data.zip?download=1',
-                         '0.1.4': 'https://zenodo.org/record/6354665/files/sample_forcing_data.zip?download=1',
-                         '0.1.5': 'https://zenodo.org/record/6354665/files/sample_forcing_data.zip?download=1',
-                         '1.0.0': 'https://zenodo.org/record/6354665/files/sample_forcing_data.zip?download=1',
-                         '1.1.0': 'https://zenodo.org/records/13344803/files/sample_forcing_data.zip?download=1',
-                         '1.2.0': 'https://zenodo.org/records/13344803/files/sample_forcing_data.zip?download=1'}
+    DATA_VERSION_URLS = {
+        '0.0.1': 'https://zenodo.org/record/6354665/files/sample_forcing_data.zip?download=1',
+        '0.1.0': 'https://zenodo.org/record/6354665/files/sample_forcing_data.zip?download=1',
+        '0.1.1': 'https://zenodo.org/record/6354665/files/sample_forcing_data.zip?download=1',
+        '0.1.2': 'https://zenodo.org/record/6354665/files/sample_forcing_data.zip?download=1',
+        '0.1.3': 'https://zenodo.org/record/6354665/files/sample_forcing_data.zip?download=1',
+        '0.1.4': 'https://zenodo.org/record/6354665/files/sample_forcing_data.zip?download=1',
+        '0.1.5': 'https://zenodo.org/record/6354665/files/sample_forcing_data.zip?download=1',
+        '1.0.0': 'https://zenodo.org/record/6354665/files/sample_forcing_data.zip?download=1',
+        '1.1.0': 'https://zenodo.org/records/13344803/files/sample_forcing_data.zip?download=1',
+        '1.2.0': 'https://zenodo.org/records/13344803/files/sample_forcing_data.zip?download=1',
+        '1.2.1': 'https://zenodo.org/records/13344803/files/sample_forcing_data.zip?download=1',
+    }
 
     DEFAULT_VERSION = 'https://zenodo.org/records/13344803/files/sample_forcing_data.zip?download=1'
 

--- a/tell/install_quickstarter_data.py
+++ b/tell/install_quickstarter_data.py
@@ -18,16 +18,19 @@ class InstallQuickstarterData:
 
     # URL for DOI minted example data hosted on Zenodo
 
-    DATA_VERSION_URLS = {'0.0.1': 'https://zenodo.org/record/6804242/files/tell_quickstarter_data.zip?download=1',
-                         '0.1.0': 'https://zenodo.org/record/6804242/files/tell_quickstarter_data.zip?download=1',
-                         '0.1.1': 'https://zenodo.org/record/6804242/files/tell_quickstarter_data.zip?download=1',
-                         '0.1.2': 'https://zenodo.org/record/6804242/files/tell_quickstarter_data.zip?download=1',
-                         '0.1.3': 'https://zenodo.org/record/6804242/files/tell_quickstarter_data.zip?download=1',
-                         '0.1.4': 'https://zenodo.org/record/6804242/files/tell_quickstarter_data.zip?download=1',
-                         '0.1.5': 'https://zenodo.org/record/6804242/files/tell_quickstarter_data.zip?download=1',
-                         '1.0.0': 'https://zenodo.org/record/6804242/files/tell_quickstarter_data.zip?download=1',
-                         '1.1.0': 'https://zenodo.org/records/13344957/files/tell_quickstarter_data.zip?download=1',
-                         '1.2.0': 'https://zenodo.org/records/13344957/files/tell_quickstarter_data.zip?download=1'}
+    DATA_VERSION_URLS = {
+        '0.0.1': 'https://zenodo.org/record/6804242/files/tell_quickstarter_data.zip?download=1',
+        '0.1.0': 'https://zenodo.org/record/6804242/files/tell_quickstarter_data.zip?download=1',
+        '0.1.1': 'https://zenodo.org/record/6804242/files/tell_quickstarter_data.zip?download=1',
+        '0.1.2': 'https://zenodo.org/record/6804242/files/tell_quickstarter_data.zip?download=1',
+        '0.1.3': 'https://zenodo.org/record/6804242/files/tell_quickstarter_data.zip?download=1',
+        '0.1.4': 'https://zenodo.org/record/6804242/files/tell_quickstarter_data.zip?download=1',
+        '0.1.5': 'https://zenodo.org/record/6804242/files/tell_quickstarter_data.zip?download=1',
+        '1.0.0': 'https://zenodo.org/record/6804242/files/tell_quickstarter_data.zip?download=1',
+        '1.1.0': 'https://zenodo.org/records/13344957/files/tell_quickstarter_data.zip?download=1',
+        '1.2.0': 'https://zenodo.org/records/13344957/files/tell_quickstarter_data.zip?download=1',
+        '1.2.1': 'https://zenodo.org/records/13344957/files/tell_quickstarter_data.zip?download=1',
+    }
 
     DEFAULT_VERSION = 'https://zenodo.org/records/13344957/files/tell_quickstarter_data.zip?download=1'
 

--- a/tell/install_raw_data.py
+++ b/tell/install_raw_data.py
@@ -29,7 +29,8 @@ class InstallRawData:
         '1.0.0': 'https://zenodo.org/record/6378036/files/tell_raw_data.zip?download=1',
         '1.1.0': 'https://zenodo.org/record/6378036/files/tell_raw_data.zip?download=1',
         '1.1.1': 'https://zenodo.org/record/6378036/files/tell_raw_data.zip?download=1',
-        '1.2.0': 'https://zenodo.org/record/6378036/files/tell_raw_data.zip?download=1'
+        '1.2.0': 'https://zenodo.org/record/6378036/files/tell_raw_data.zip?download=1',
+        '1.2.1': 'https://zenodo.org/record/6378036/files/tell_raw_data.zip?download=1',
     }
 
     DEFAULT_VERSION = 'https://zenodo.org/record/6378036/files/tell_raw_data.zip?download=1'


### PR DESCRIPTION
Set max Python version to 3.10 due to scikit learn 1.0 requiring Python 3.7-3.10.

Also fixed a future depreciation warning related to using "YE" instead of "Y" for year designation.